### PR TITLE
Allow textures with ID > NUM_TEXTURES to be loaded

### DIFF
--- a/src/game/bondgun.c
+++ b/src/game/bondgun.c
@@ -3900,7 +3900,7 @@ void bgunTickGunLoad(void)
 		for (i = player->gunctrl.nexttexturetoload; i < modeldef->numtexconfigs; i++) {
 			osSyncPrintf("BriGun:  at texture %d\n", i);
 
-			if (modeldef->texconfigs[i].texturenum < NUM_TEXTURES) {
+			if (modeldef->texconfigs[i].texturenum < MAX_TEXTURES) {
 				osSyncPrintf("BriGun:  Uncompress %d of %d\n", i, modeldef->numtexconfigs);
 				texLoad(&modeldef->texconfigs[i].texturenum, &player->gunctrl.texpool, true);
 				modeldef->texconfigs[i].unk0b = 1;
@@ -11222,7 +11222,7 @@ void bgunPlayPropHitSound(struct gset *gset, struct prop *prop, s32 texturenum)
 		return;
 	}
 
-	if (texturenum >= 0 && texturenum < NUM_TEXTURES
+	if (texturenum >= 0 && texturenum < MAX_TEXTURES
 			&& g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]->numsounds == 0) {
 		return;
 	}
@@ -11338,7 +11338,7 @@ void bgunPlayPropHitSound(struct gset *gset, struct prop *prop, s32 texturenum)
 		}
 	}
 
-	if (texturenum >= 0 && texturenum < NUM_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]) {
+	if (texturenum >= 0 && texturenum < MAX_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]) {
 		s16 soundnum = -1;
 
 		handle = bgunAllocateAudioHandle();
@@ -11367,7 +11367,7 @@ void bgunPlayPropHitSound(struct gset *gset, struct prop *prop, s32 texturenum)
 		return;
 	}
 
-	if (texturenum >= 0 && texturenum < NUM_TEXTURES
+	if (texturenum >= 0 && texturenum < MAX_TEXTURES
 			&& g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]->numsounds == 0) {
 		return;
 	}
@@ -11471,7 +11471,7 @@ void bgunPlayPropHitSound(struct gset *gset, struct prop *prop, s32 texturenum)
 		}
 	}
 
-	if (texturenum >= 0 && texturenum < NUM_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]) {
+	if (texturenum >= 0 && texturenum < MAX_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]) {
 		s16 soundnum = -1;
 
 		handle = bgunAllocateAudioHandle();
@@ -11521,7 +11521,7 @@ void bgunPlayBgHitSound(struct gset *gset, struct coord *hitpos, s32 texturenum,
 		return;
 	}
 
-	if (texturenum >= 0 && texturenum < NUM_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]->numsounds == 0) {
+	if (texturenum >= 0 && texturenum < MAX_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]->numsounds == 0) {
 		return;
 	}
 
@@ -11589,7 +11589,7 @@ void bgunPlayBgHitSound(struct gset *gset, struct coord *hitpos, s32 texturenum,
 	if (playdefault) {
 		handle = bgunAllocateAudioHandle();
 
-		if (handle != NULL && texturenum >= 0 && texturenum < NUM_TEXTURES) {
+		if (handle != NULL && texturenum >= 0 && texturenum < MAX_TEXTURES) {
 			s16 soundnum;
 			struct surfacetype *type = g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype];
 
@@ -11619,7 +11619,7 @@ void bgunPlayBgHitSound(struct gset *gset, struct coord *hitpos, s32 texturenum,
 		return;
 	}
 
-	if (texturenum >= 0 && texturenum < NUM_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]->numsounds == 0) {
+	if (texturenum >= 0 && texturenum < MAX_TEXTURES && g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype]->numsounds == 0) {
 		return;
 	}
 
@@ -11682,7 +11682,7 @@ void bgunPlayBgHitSound(struct gset *gset, struct coord *hitpos, s32 texturenum,
 	// Play default surface hit sound
 	handle = bgunAllocateAudioHandle();
 
-	if (handle != NULL && texturenum >= 0 && texturenum < NUM_TEXTURES) {
+	if (handle != NULL && texturenum >= 0 && texturenum < MAX_TEXTURES) {
 		s16 soundnum;
 		struct surfacetype *type = g_SurfaceTypes[g_Textures[texturenum].soundsurfacetype];
 

--- a/src/game/chr.c
+++ b/src/game/chr.c
@@ -4706,7 +4706,7 @@ void chrHit(struct shotdata *shotdata, struct hit *hit)
 				}
 
 				// Create decal depending on the weapon's surface type
-				if (hit->hitthing.texturenum < 0 || hit->hitthing.texturenum >= NUM_TEXTURES) {
+				if (hit->hitthing.texturenum < 0 || hit->hitthing.texturenum >= MAX_TEXTURES) {
 					surfacetype = SURFACETYPE_DEFAULT;
 				} else {
 					surfacetype = g_Textures[hit->hitthing.texturenum].surfacetype;

--- a/src/game/prop.c
+++ b/src/game/prop.c
@@ -817,7 +817,7 @@ struct prop *shotCalculateHits(s32 handnum, bool isshooting, struct coord *gunpo
 
 			texnum = lightsHandleHit(&shotdata.gunpos3d, &hitpos, room);
 
-			if (sp694.texturenum < 0 || sp694.texturenum >= NUM_TEXTURES) {
+			if (sp694.texturenum < 0 || sp694.texturenum >= MAX_TEXTURES) {
 				surfacetype = g_SurfaceTypes[SURFACETYPE_DEFAULT];
 			} else {
 				index = g_Textures[sp694.texturenum].surfacetype;

--- a/src/game/propobj.c
+++ b/src/game/propobj.c
@@ -15882,7 +15882,7 @@ void objHit(struct shotdata *shotdata, struct hit *hit)
 			s8 spcb = false;
 			bool spc4;
 
-			if (hit->hitthing.texturenum < 0 || hit->hitthing.texturenum >= NUM_TEXTURES) {
+			if (hit->hitthing.texturenum < 0 || hit->hitthing.texturenum >= MAX_TEXTURES) {
 				surfacetype = g_SurfaceTypes[0];
 			} else if (g_Textures[hit->hitthing.texturenum].surfacetype < 15) {
 				surfacetype = g_SurfaceTypes[g_Textures[hit->hitthing.texturenum].surfacetype];

--- a/src/game/splat.c
+++ b/src/game/splat.c
@@ -344,7 +344,7 @@ bool splat0f149274(f32 arg0, struct prop *chrprop, struct shotdata *shotdata, f3
 			struct hit *hit = &stackshotdata.hits[i];
 
 			if (hit->prop && (hit->hitthing.texturenum < 0
-						|| hit->hitthing.texturenum >= NUM_TEXTURES
+						|| hit->hitthing.texturenum >= MAX_TEXTURES
 						|| g_SurfaceTypes[g_Textures[hit->hitthing.texturenum].surfacetype]->numwallhittexes != 0)) {
 				sp50c = &hit->hitthing.pos;
 				hitpos = &hit->pos;

--- a/src/game/tex.c
+++ b/src/game/tex.c
@@ -891,7 +891,8 @@ s32 texLoadFromGdl(Gfx *instart, s32 gdlsizeinbytes, Gfx *outstart, struct texpo
 				spe8 = true;
 			}
 
-			texturenum = ingdl->words.w1 & 0xfff;
+			texturenum = ingdl->words.w1 & (ingdl->unkc0.subcmd == 1 ? 0xfff : 0xffff);
+
 			flag = ingdl->words.w0 & 0x200;
 
 			texLoadFromTextureNum(texturenum, pool);

--- a/src/game/texdecompress.c
+++ b/src/game/texdecompress.c
@@ -2245,7 +2245,7 @@ void texLoad(texnum_t *updateword, struct texpool *pool, bool unusedarg)
 		tex = texFindInPool(g_TexNumToLoad, pool);
 
 		if (tex == NULL) {
-			if (g_TexNumToLoad >= NUM_TEXTURES) {
+			if (g_TexNumToLoad >= MAX_TEXTURES) {
 				return;
 			}
 
@@ -2260,7 +2260,7 @@ void texLoad(texnum_t *updateword, struct texpool *pool, bool unusedarg)
 			thisoffset = g_Textures[g_TexNumToLoad].dataoffset;
 			nextoffset = g_Textures[g_TexNumToLoad + 1].dataoffset;
 
-			if (thisoffset == nextoffset) {
+			if (thisoffset == nextoffset && g_TexNumToLoad < NUM_TEXTURES) {
 				// The texture has no data
 				return;
 			}
@@ -2387,7 +2387,7 @@ void texLoadFromConfigs(struct textureconfig *configs, s32 numconfigs, struct te
 	s32 i;
 
 	for (i = 0; i < numconfigs; i++) {
-		if ((uintptr_t)configs[i].texturenum < NUM_TEXTURES) {
+		if ((uintptr_t)configs[i].texturenum < MAX_TEXTURES) {
 			texLoad(&configs[i].texturenum, pool, true);
 			configs[i].unk0b = 1;
 		} else {

--- a/src/game/texselect.c
+++ b/src/game/texselect.c
@@ -244,7 +244,7 @@ void texSetRenderMode(Gfx **gdlptr, s32 arg1, s32 numcycles, s32 arg3)
 
 void texLoadFromConfig(struct textureconfig *config)
 {
-	if ((u32)config->texturenum < NUM_TEXTURES) {
+	if ((u32)config->texturenum < MAX_TEXTURES) {
 		texLoadFromConfigs(config, 1, NULL, 0);
 	}
 }
@@ -282,7 +282,7 @@ void texSelect(Gfx **gdlptr, struct textureconfig *tconfig, u32 arg2, s32 arg3, 
 
 		tex = NULL;
 
-		if ((u32)tconfig->texturenum < NUM_TEXTURES) {
+		if ((u32)tconfig->texturenum < MAX_TEXTURES) {
 			texLoadFromConfigs(tconfig, 1, pool, 0);
 		}
 

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -38,6 +38,7 @@
 #define NUM_MPWEAPONSLOTS     6
 #define NUM_SOLOSTAGES        21
 #define NUM_TEXTURES          (VERSION == VERSION_JPN_FINAL ? 3511 : 3503)
+#define MAX_TEXTURES          8192
 
 #define osSyncPrintf
 

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -6030,7 +6030,7 @@ struct awardmetrics {
 };
 
 struct tex {
-	/*0x00*/ u16 texturenum : 12;
+	/*0x00*/ u16 texturenum;
 	/*0x04*/ u8 *data;
 	/*0x08*/ u8 width;
 	/*0x09*/ u8 height;


### PR DESCRIPTION
This allows mods to use textures with IDs > NUM_TEXTURES, which is 3503 in the NTSC version and 3511 in the JPN version.
The feature is still incomplete, because we also need a way to configure the texture's surface and sound types. 
This should be part of the upcoming mod config feature, which will allow modders to specify the various mod configs in a config file.