### PR TITLE
Fix Matrix test room rendering and PC asset loading

### DIFF
--- a/port/fast3d/gfx_pc.cpp
+++ b/port/fast3d/gfx_pc.cpp
@@ -1191,6 +1191,85 @@ static inline int gfx_lod_tile_offset(const int i) {
     return (rdp.tex_lod ? rdp.tex_detail : i);
 }
 
+// Interpolate every attribute of a LoadedVertex along the edge a->b at t.
+static void gfx_clip_lerp_vertex(struct LoadedVertex* out, const struct LoadedVertex* a,
+                                 const struct LoadedVertex* b, float t) {
+    out->x = a->x + (b->x - a->x) * t;
+    out->y = a->y + (b->y - a->y) * t;
+    out->z = a->z + (b->z - a->z) * t;
+    out->w = a->w + (b->w - a->w) * t;
+    out->u = a->u + (b->u - a->u) * t;
+    out->v = a->v + (b->v - a->v) * t;
+    out->color.r = (uint8_t)(a->color.r + (b->color.r - a->color.r) * t);
+    out->color.g = (uint8_t)(a->color.g + (b->color.g - a->color.g) * t);
+    out->color.b = (uint8_t)(a->color.b + (b->color.b - a->color.b) * t);
+    out->color.a = (uint8_t)(a->color.a + (b->color.a - a->color.a) * t);
+    out->fog = (uint8_t)(a->fog + (b->fog - a->fog) * t);
+    out->clip_rej = 0;
+}
+
+// Clip a triangle against the near plane (clip-space z + w >= 0). This port
+// otherwise leaves near clipping to the GL driver, but vertices behind the eye
+// (w <= 0) project to garbage coordinates that intermittently corrupt the
+// macOS GL driver's heap. Produces up to two output triangles whose vertices
+// all lie in front of the near plane. New vertices are written into
+// clip_storage (needs room for 2). Returns the number of triangles (0, 1 or 2).
+static int gfx_clip_triangle_near(struct LoadedVertex* v1, struct LoadedVertex* v2, struct LoadedVertex* v3,
+                                  struct LoadedVertex* out_tris[2][3], struct LoadedVertex clip_storage[2]) {
+    struct LoadedVertex* in[3] = { v1, v2, v3 };
+    float d[3];
+    int n_in = 0;
+    for (int i = 0; i < 3; i++) {
+        d[i] = in[i]->z + in[i]->w; // signed distance to near plane
+        if (d[i] >= 0.0f) {
+            n_in++;
+        }
+    }
+    if (n_in == 3) {
+        out_tris[0][0] = v1;
+        out_tris[0][1] = v2;
+        out_tris[0][2] = v3;
+        return 1;
+    }
+    if (n_in == 0) {
+        return 0;
+    }
+
+    // Sutherland-Hodgman against the single near plane.
+    struct LoadedVertex* poly[4];
+    int poly_n = 0;
+    int storage_used = 0;
+    for (int i = 0; i < 3; i++) {
+        int j = (i + 1) % 3;
+        bool ini = d[i] >= 0.0f;
+        bool inj = d[j] >= 0.0f;
+        if (ini) {
+            poly[poly_n++] = in[i];
+        }
+        if (ini != inj) {
+            float t = d[i] / (d[i] - d[j]);
+            struct LoadedVertex* nv = &clip_storage[storage_used++];
+            gfx_clip_lerp_vertex(nv, in[i], in[j], t);
+            poly[poly_n++] = nv;
+        }
+    }
+
+    if (poly_n < 3) {
+        return 0;
+    }
+
+    out_tris[0][0] = poly[0];
+    out_tris[0][1] = poly[1];
+    out_tris[0][2] = poly[2];
+    if (poly_n == 4) {
+        out_tris[1][0] = poly[0];
+        out_tris[1][1] = poly[2];
+        out_tris[1][2] = poly[3];
+        return 2;
+    }
+    return 1;
+}
+
 static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bool is_rect) {
     struct LoadedVertex* v1 = &rsp.loaded_vertices[vtx1_idx];
     struct LoadedVertex* v2 = &rsp.loaded_vertices[vtx2_idx];
@@ -1416,6 +1495,26 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
 
     struct GfxClipParameters clip_parameters = gfx_rapi->get_clip_parameters();
 
+    // Near-plane clip this triangle into 0-2 triangles whose vertices are all
+    // in front of the eye, then emit each. Without this, behind-eye vertices
+    // reach the GL driver and corrupt its heap (crash during buffer swap).
+    struct LoadedVertex gfx_clip_storage[2];
+    struct LoadedVertex* gfx_clip_tris[2][3];
+    int gfx_num_clip_tris;
+    if (!is_rect && (rsp.extra_geometry_mode & G_NO_CLIPPING_EXT) == 0) {
+        gfx_num_clip_tris = gfx_clip_triangle_near(v1, v2, v3, gfx_clip_tris, gfx_clip_storage);
+    } else {
+        gfx_clip_tris[0][0] = v1;
+        gfx_clip_tris[0][1] = v2;
+        gfx_clip_tris[0][2] = v3;
+        gfx_num_clip_tris = 1;
+    }
+
+    for (int ct = 0; ct < gfx_num_clip_tris; ct++) {
+        v_arr[0] = gfx_clip_tris[ct][0];
+        v_arr[1] = gfx_clip_tris[ct][1];
+        v_arr[2] = gfx_clip_tris[ct][2];
+
     for (int i = 0; i < 3; i++) {
         float z = v_arr[i]->z, w = v_arr[i]->w;
         if (clip_parameters.z_is_from_0_to_1) {
@@ -1569,6 +1668,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     if (++buf_vbo_num_tris == MAX_BUFFERED) {
         gfx_flush();
     }
+    } // end near-plane-clipped triangle loop
 }
 
 static inline void gfx_sp_tri4(Gfx *cmd) {
@@ -2501,7 +2601,7 @@ static void gfx_run_dl(Gfx* cmd) {
             case G_RDPTILESYNC:
                 break;
             default:
-                sysFatalError("Unknown GBI opcode 0x%02x at %p.\nw0 %08x\nw1 %08x", opcode, cmd, cmd->words.w0, cmd->words.w1);
+                sysFatalError("Unknown GBI opcode 0x%02x at %p.\nw0 0x%08llx\nw1 0x%08llx", (unsigned int)opcode, cmd, (unsigned long long)cmd->words.w0, (unsigned long long)cmd->words.w1);
                 break;
         }
         ++cmd;

--- a/port/src/fs.c
+++ b/port/src/fs.c
@@ -64,6 +64,7 @@ s32 fsPathIsCwdRelative(const char *path)
 const char *fsFullPath(const char *relPath)
 {
 	static char pathBuf[FS_MAXPATH + 1];
+	struct stat st;
 
 	if (relPath[0] == '$') {
 		// expandable placeholder $X; will be replaced with the corresponding path, if any
@@ -94,27 +95,27 @@ const char *fsFullPath(const char *relPath)
 	// path relative to mod or base dir; this will be a read request, so check where the file actually is
 	if (gexModDir[0] && g_ModNum == MOD_GEX) {
 		snprintf(pathBuf, FS_MAXPATH, "%s/%s", gexModDir, relPath);
-		if (fsFileSize(pathBuf) >= 0) {
+		if (stat(pathBuf, &st) == 0) {
 			return pathBuf;
 		}
 	} else if (kakarikoModDir[0] && g_ModNum == MOD_KAKARIKO) {
 		snprintf(pathBuf, FS_MAXPATH, "%s/%s", kakarikoModDir, relPath);
-		if (fsFileSize(pathBuf) >= 0) {
+		if (stat(pathBuf, &st) == 0) {
 			return pathBuf;
 		}
 	} else if (darknoonModDir[0] && g_ModNum == MOD_DARKNOON) {
 		snprintf(pathBuf, FS_MAXPATH, "%s/%s", darknoonModDir, relPath);
-		if (fsFileSize(pathBuf) >= 0) {
+		if (stat(pathBuf, &st) == 0) {
 			return pathBuf;
 		}
 	} else if (goldfinger64ModDir[0] && g_ModNum == MOD_GOLDFINGER_64) {
 		snprintf(pathBuf, FS_MAXPATH, "%s/%s", goldfinger64ModDir, relPath);
-		if (fsFileSize(pathBuf) >= 0) {
+		if (stat(pathBuf, &st) == 0) {
 			return pathBuf;
 		}
 	} else if (modDir[0]) {
 		snprintf(pathBuf, FS_MAXPATH, "%s/%s", modDir, relPath);
-		if (fsFileSize(pathBuf) >= 0) {
+		if (stat(pathBuf, &st) == 0) {
 			return pathBuf;
 		}
 	}
@@ -369,6 +370,7 @@ s32 fsFileLoadTo(const char *name, void *dst, u32 dstSize)
 void *fsFileLoad(const char *name, u32 *outSize)
 {
 	const char *fullName = fsFullPath(name);
+	sysLogPrintf(LOG_NOTE, "fsFileLoad: name=%s resolved to=%s", name, fullName);
 
 	FILE *f = fopen(fullName, "rb");
 	if (!f) {

--- a/port/src/preprocess/filebg.c
+++ b/port/src/preprocess/filebg.c
@@ -444,7 +444,8 @@ static u32 convertSection1(u8 *dst, u8 *src, u32 ofs)
 
 void preprocessBgSection1(u8 *data, u32 size, u32 ofs)
 {
-	u8 *dst = sysMemZeroAlloc(size);
+	u32 allocSize = size * 2 + 16384;
+	u8 *dst = sysMemZeroAlloc(allocSize);
 
 	u32 newSize = convertSection1(dst, data, ofs);
 

--- a/port/src/romdata.c
+++ b/port/src/romdata.c
@@ -725,13 +725,13 @@ u32 romdataFileGetEstimatedSize(const u32 size, const u32 loadtype)
 {
 #ifdef PLATFORM_64BIT
 	switch (loadtype) {
-	case LOADTYPE_BG:	   return (u32)(size * 1.1f);
-	case LOADTYPE_TILES: return (u32)(size * 1.1f);
-	case LOADTYPE_LANG:  return (u32)(size * 1.3f);
-	case LOADTYPE_SETUP: return (u32)(size * 1.5f);
-	case LOADTYPE_PADS:  return (u32)(size * 1.7f);
-	case LOADTYPE_MODEL: return (u32)(size * 1.7f);
-	case LOADTYPE_GUN: return (u32)(size * 1.7f);
+	case LOADTYPE_BG:    return (u32)(size * 1.5f) + 16384;
+	case LOADTYPE_TILES: return (u32)(size * 1.5f) + 16384;
+	case LOADTYPE_LANG:  return (u32)(size * 1.5f) + 16384;
+	case LOADTYPE_SETUP: return (u32)(size * 30.0f) + 16384;
+	case LOADTYPE_PADS:  return (u32)(size * 30.0f) + 16384;
+	case LOADTYPE_MODEL: return (u32)(size * 30.0f) + 16384;
+	case LOADTYPE_GUN:   return (u32)(size * 30.0f) + 16384;
 	default:
 		sysLogPrintf(LOG_WARNING, "romdataFileGetEstimatedSize: wrong loadtype %d", loadtype);
 	}

--- a/src/game/bg.c
+++ b/src/game/bg.c
@@ -179,10 +179,6 @@ void bgSetRoomOnscreen(s32 roomnum, s32 draworder, struct screenbox *box)
 {
 	s32 index;
 
-#if VERSION < VERSION_NTSC_1_0
-	g_Rooms[roomnum].flags |= ROOMFLAG_ONSCREEN;
-#endif
-
 	if ((g_Rooms[roomnum].flags & ROOMFLAG_DISABLEDBYSCRIPT) == 0) {
 #if VERSION >= VERSION_NTSC_1_0
 		g_Rooms[roomnum].flags |= ROOMFLAG_ONSCREEN;
@@ -1986,6 +1982,25 @@ void bgBuildTables(s32 stagenum)
 					+ (g_Rooms[r].bbmin[1] - g_Rooms[r].bbmax[1]) * (g_Rooms[r].bbmin[1] - g_Rooms[r].bbmax[1])
 					+ (g_Rooms[r].bbmin[2] - g_Rooms[r].bbmax[2]) * (g_Rooms[r].bbmin[2] - g_Rooms[r].bbmax[2])) / 2.0f;
 		}
+		if (g_Vars.stagenum == STAGE_TEST_UFF) {
+			// Matrix Test Room: force room 1's bbox to the full box arena so
+			// collision-geo collection and culling cover every spawn. These
+			// extents MUST match the box built by tools/pdmap (BOX_HALF /
+			// BOX_HEIGHT in src/levels/uff.py and the floor tiles): the floor
+			// spans +/-5000 on X/Z with a 3000-tall ceiling. Using a smaller
+			// box here makes outer spawns fall through the floor.
+			g_Rooms[1].bbmin[0] = -5000.0f;
+			g_Rooms[1].bbmin[1] = 0.0f;
+			g_Rooms[1].bbmin[2] = -5000.0f;
+			g_Rooms[1].bbmax[0] = 5000.0f;
+			g_Rooms[1].bbmax[1] = 3000.0f;
+			g_Rooms[1].bbmax[2] = 5000.0f;
+			g_Rooms[1].centre.x = 0.0f;
+			g_Rooms[1].centre.y = 1500.0f;
+			g_Rooms[1].centre.z = 0.0f;
+			// Bounding sphere radius: half the box diagonal (~7416).
+			g_Rooms[1].radius = 7500.0f;
+		}
 
 		// The next part of section 3 is a list of roomgfxdata sizes.
 		// There is one per room and the value needs to be multiplied by 0x10.
@@ -2856,6 +2871,22 @@ void bgLoadRoom(s32 roomnum)
 		readlen = ((g_BgRooms[roomnum + 1].unk00 - g_BgRooms[roomnum].unk00) + 0xf) & ~0xf;
 		fileoffset = (g_BgPrimaryData + g_BgRooms[roomnum].unk00 - g_BgPrimaryData) - 0x0f000000;
 		fileoffset -= var8007fc54;
+		// A zero-length room has no compressed geometry. This happens for the
+		// phantom rooms emitted by the procedural single-room arena builder
+		// (tools/pdmap): the room table needs an end-marker entry, which the
+		// engine otherwise treats as a real (empty) room. Inflating/preprocessing
+		// 0 bytes overflows the scratch buffer and crashes ("overflow when
+		// trying to preprocess a bg room, size 0"). Treat it as an empty loaded
+		// room with no gfxdata instead.
+		if (readlen == 0) {
+#ifndef PLATFORM_N64
+			sysMemFree(allocation);
+#endif
+			g_Rooms[roomnum].gfxdata = NULL;
+			g_Rooms[roomnum].loaded240 = 1;
+			dyntexSetCurrentRoom(-1);
+			return;
+		}
 
 		if (readlen > alloclen) {
 			dyntexSetCurrentRoom(-1);
@@ -3032,8 +3063,8 @@ void bgLoadRoom(s32 roomnum)
 
 		// Do some find/replaces in the gdls based on environment configuration
 		if (g_Vars.stagenum == STAGE_TEST_UFF) {
-			gfxMakeRoomWhiteRecursively(g_Rooms[roomnum].gfxdata->opablocks);
-			gfxMakeRoomWhiteRecursively(g_Rooms[roomnum].gfxdata->xlublocks);
+			gfxMakeRoomUseShadeRecursively(g_Rooms[roomnum].gfxdata->opablocks);
+			gfxMakeRoomUseShadeRecursively(g_Rooms[roomnum].gfxdata->xlublocks);
 		} else if (g_FogEnabled) {
 			gfxReplaceGbiCommandsRecursively(g_Rooms[roomnum].gfxdata->opablocks, 1);
 			gfxReplaceGbiCommandsRecursively(g_Rooms[roomnum].gfxdata->xlublocks, 5);
@@ -3306,16 +3337,16 @@ Gfx *bgRenderRoomPass(Gfx *gdl, s32 roomnum, struct roomblock *block, bool arg3)
  */
 Gfx *bgRenderRoomOpaque(Gfx *gdl, s32 roomnum)
 {
-	if (g_Rooms[roomnum].loaded240 == 0) {
+	// Skip unloaded rooms and empty rooms with no geometry (e.g. the phantom
+	// end-marker rooms emitted by the procedural arena builder, which load with
+	// a NULL gfxdata). Without this guard, dereferencing gfxdata crashes.
+	if (g_Rooms[roomnum].loaded240 == 0 || g_Rooms[roomnum].gfxdata == NULL) {
 		return gdl;
 	}
 
 	gdl = roomApplyMtx(gdl, roomnum);
 
 	gdl = lightsSetForRoom(gdl, roomnum);
-	if (g_Vars.stagenum == STAGE_TEST_UFF) {
-		gDPSetPrimColor(gdl++, 0, 0, 255, 255, 255, 255);
-	}
 	gdl = bgRenderRoomPass(gdl, roomnum, g_Rooms[roomnum].gfxdata->opablocks, true);
 	gdl = lightsSetDefault(gdl);
 
@@ -3336,7 +3367,8 @@ Gfx *bgRenderRoomXlu(Gfx *gdl, s32 roomnum)
 	}
 
 	if (g_Rooms[roomnum].loaded240) {
-		if (g_Rooms[roomnum].gfxdata->xlublocks == NULL) {
+		// Empty rooms (phantom end-markers) load with NULL gfxdata; skip them.
+		if (g_Rooms[roomnum].gfxdata == NULL || g_Rooms[roomnum].gfxdata->xlublocks == NULL) {
 			return gdl;
 		}
 
@@ -3346,9 +3378,6 @@ Gfx *bgRenderRoomXlu(Gfx *gdl, s32 roomnum)
 		if (g_Rooms[roomnum].gfxdata);
 
 		gdl = roomApplyMtx(gdl, roomnum);
-		if (g_Vars.stagenum == STAGE_TEST_UFF) {
-			gDPSetPrimColor(gdl++, 0, 0, 255, 255, 255, 255);
-		}
 		gdl = bgRenderRoomPass(gdl, roomnum, g_Rooms[roomnum].gfxdata->xlublocks, true);
 
 		g_Rooms[roomnum].loaded240 = 1;
@@ -5867,8 +5896,21 @@ void bgTickPortals(void)
 
 		if (!g_BgRoomTestsDisabled) {
 			if (g_BgPortals[0].verticesoffset == 0) {
+				// Portal-less arenas (e.g. the Matrix Test Room box) have no PVS
+				// graph, so the room the player stands in must be forced on every
+				// frame — exactly like the portal path below does for g_CamRoom.
+				// Without this the screen-box test can reject the camera room, it
+				// never loads (loaded240 stays 0), its floor collision is never
+				// collected, and the player falls through the world.
+				if (g_CamRoom >= 1 && g_CamRoom < g_Vars.roomcount) {
+					bgSetRoomOnscreen(g_CamRoom, 0, &box);
+				}
 				for (room = 1; room < g_Vars.roomcount; room++) {
-					if (bgRoomIntersectsScreenBox(room, &box)
+					if (room == g_CamRoom) {
+						continue; // already forced on above
+					}
+					bool intersects = bgRoomIntersectsScreenBox(room, &box);
+					if (intersects
 							&& ((g_StageIndex != STAGEINDEX_INFILTRATION && g_StageIndex != STAGEINDEX_RESCUE && g_StageIndex != STAGEINDEX_ESCAPE) || room != 0xf)
 							&& (g_StageIndex != STAGEINDEX_SKEDARRUINS || room != 0x02)
 							&& ((g_StageIndex != STAGEINDEX_DEFECTION && g_StageIndex != STAGEINDEX_EXTRACTION) || room != 0x01)

--- a/src/game/bg.c
+++ b/src/game/bg.c
@@ -3031,7 +3031,10 @@ void bgLoadRoom(s32 roomnum)
 		}
 
 		// Do some find/replaces in the gdls based on environment configuration
-		if (g_FogEnabled) {
+		if (g_Vars.stagenum == STAGE_TEST_UFF) {
+			gfxMakeRoomWhiteRecursively(g_Rooms[roomnum].gfxdata->opablocks);
+			gfxMakeRoomWhiteRecursively(g_Rooms[roomnum].gfxdata->xlublocks);
+		} else if (g_FogEnabled) {
 			gfxReplaceGbiCommandsRecursively(g_Rooms[roomnum].gfxdata->opablocks, 1);
 			gfxReplaceGbiCommandsRecursively(g_Rooms[roomnum].gfxdata->xlublocks, 5);
 		} else if (!g_EnvHasTransparency) {
@@ -3310,6 +3313,9 @@ Gfx *bgRenderRoomOpaque(Gfx *gdl, s32 roomnum)
 	gdl = roomApplyMtx(gdl, roomnum);
 
 	gdl = lightsSetForRoom(gdl, roomnum);
+	if (g_Vars.stagenum == STAGE_TEST_UFF) {
+		gDPSetPrimColor(gdl++, 0, 0, 255, 255, 255, 255);
+	}
 	gdl = bgRenderRoomPass(gdl, roomnum, g_Rooms[roomnum].gfxdata->opablocks, true);
 	gdl = lightsSetDefault(gdl);
 
@@ -3340,6 +3346,9 @@ Gfx *bgRenderRoomXlu(Gfx *gdl, s32 roomnum)
 		if (g_Rooms[roomnum].gfxdata);
 
 		gdl = roomApplyMtx(gdl, roomnum);
+		if (g_Vars.stagenum == STAGE_TEST_UFF) {
+			gDPSetPrimColor(gdl++, 0, 0, 255, 255, 255, 255);
+		}
 		gdl = bgRenderRoomPass(gdl, roomnum, g_Rooms[roomnum].gfxdata->xlublocks, true);
 
 		g_Rooms[roomnum].loaded240 = 1;

--- a/src/game/env.c
+++ b/src/game/env.c
@@ -135,7 +135,7 @@ struct nofogenvironment g_NoFogEnvironments[] = {
 	{ STAGE_MP_G5BUILDING, 15, 10000,   0,  0,  0, RGB(0x000008), NO_SUNS,            1, RGB(0x5a90a5),  4500,   0, 0, RGB(0x000000), -20000,    0, 0, 0 },
 	{ STAGE_MP_TEMPLE,     15, 10000,   0,  0,  0, RGB(0x001080), NO_SUNS,            1, RGB(0xffffff),  5000,   0, 0, RGB(0x00ffff),  -1850,    1, 0, 1 },
 	{ STAGE_MP_COMPLEX,    15, 10000,   0,  0,  0, RGB(0x020000), NO_SUNS,            1, RGB(0x82aac8),  5000,   0, 0, RGB(0x000000),  -5000,    0, 0, 0 },
-	{ STAGE_TEST_UFF,      10, 10000,   0,  0,  0, RGB(0x000000), NO_SUNS,            0, RGB(0x1e1e1e),  5000,   0, 0, RGB(0x000000),  -5000,    0, 0, 0 },
+	{ STAGE_TEST_UFF,      10, 10000,   0,  0,  0, RGB(0x000000), NO_SUNS,            0, RGB(0xcccccc),  5000,   0, 0, RGB(0x000000),  -5000,    0, 0, 0 },
 	{ STAGE_TEST_OLD,      15, 30000,   0,  0,  0, RGB(0x000000), NO_SUNS,            0, RGB(0x1e1e1e),  5000,   0, 0, RGB(0x000000),  -5000,    0, 0, 0 },
 #ifdef PLATFORM_N64 // GoldenEye X Mod
 	{ STAGE_TEST_LAM,      15, 20000,   0,  0,  0, RGB(0x000000), NO_SUNS,            0, RGB(0x1e1e1e),  5000,   0, 0, RGB(0x000000),  -5000,    0, 0, 0 },

--- a/src/game/gfxreplace.c
+++ b/src/game/gfxreplace.c
@@ -354,3 +354,39 @@ void gfxReplaceGbiCommandsRecursively(struct roomblock *block, s32 type)
 		}
 	}
 }
+
+void gfxMakeRoomWhite(Gfx *startgdl)
+{
+	Gfx *gdl = startgdl;
+
+	while (*(s8 *)gdl != (s8)G_ENDDL) {
+		u8 opcode = (gdl->words.w0 >> 24) & 0xff;
+
+		if (opcode == (u8)G_SETCOMBINE) {
+			*gdl = (Gfx)gsDPSetCombineMode(G_CC_PRIMITIVE, G_CC_PRIMITIVE);
+		}
+		gdl++;
+	}
+}
+
+void gfxMakeRoomWhiteRecursively(struct roomblock *block)
+{
+	while (true) {
+		if (!block) {
+			return;
+		}
+
+		switch (block->type) {
+		case ROOMBLOCKTYPE_LEAF:
+			gfxMakeRoomWhite(block->gdl);
+			block = block->next;
+			break;
+		case ROOMBLOCKTYPE_PARENT:
+			gfxMakeRoomWhiteRecursively(block->child);
+			block = block->next;
+			break;
+		default:
+			return;
+		}
+	}
+}

--- a/src/game/gfxreplace.c
+++ b/src/game/gfxreplace.c
@@ -355,21 +355,34 @@ void gfxReplaceGbiCommandsRecursively(struct roomblock *block, s32 type)
 	}
 }
 
-void gfxMakeRoomWhite(Gfx *startgdl)
+void gfxMakeRoomUseShade(Gfx *startgdl)
 {
+	if (!startgdl) {
+		return;
+	}
+
 	Gfx *gdl = startgdl;
 
-	while (*(s8 *)gdl != (s8)G_ENDDL) {
-		u8 opcode = (gdl->words.w0 >> 24) & 0xff;
+	// Bound the walk: a well-formed room gdl always terminates with G_ENDDL.
+	// Guarding against a runaway walk avoids a hard crash if a room's display
+	// list is ever malformed.
+	s32 guard = 0;
+	while (gdl->bytes[GFX_W0_BYTE(0)] != (u8)G_ENDDL) {
+		u8 opcode = gdl->bytes[GFX_W0_BYTE(0)];
+
+		if (++guard > 4096) {
+			break;
+		}
 
 		if (opcode == (u8)G_SETCOMBINE) {
-			*gdl = (Gfx)gsDPSetCombineMode(G_CC_PRIMITIVE, G_CC_PRIMITIVE);
+			gDPSetCombineMode(gdl, G_CC_SHADE, G_CC_SHADE);
 		}
+
 		gdl++;
 	}
 }
 
-void gfxMakeRoomWhiteRecursively(struct roomblock *block)
+void gfxMakeRoomUseShadeRecursively(struct roomblock *block)
 {
 	while (true) {
 		if (!block) {
@@ -378,11 +391,11 @@ void gfxMakeRoomWhiteRecursively(struct roomblock *block)
 
 		switch (block->type) {
 		case ROOMBLOCKTYPE_LEAF:
-			gfxMakeRoomWhite(block->gdl);
+			gfxMakeRoomUseShade(block->gdl);
 			block = block->next;
 			break;
 		case ROOMBLOCKTYPE_PARENT:
-			gfxMakeRoomWhiteRecursively(block->child);
+			gfxMakeRoomUseShadeRecursively(block->child);
 			block = block->next;
 			break;
 		default:

--- a/src/game/portal.c
+++ b/src/game/portal.c
@@ -75,7 +75,7 @@ s32 g_NumPortalXluFracs;
 
 void portalSetXluFrac2(s32 portalnum, f32 frac)
 {
-	if (portalnum >= 0) {
+	if (portalnum >= 0 && g_PortalXluFracs) {
 		u8 value = (u32)(255 * frac);
 		value <<= 0;
 		g_PortalXluFracs[portalnum] = (g_PortalXluFracs[portalnum] & 0xff00) | value;
@@ -84,7 +84,7 @@ void portalSetXluFrac2(s32 portalnum, f32 frac)
 
 void portalSetXluFrac(s32 portalnum, f32 frac)
 {
-	if (portalnum >= 0) {
+	if (portalnum >= 0 && g_PortalXluFracs) {
 		u8 value = (u32)(15 * frac) & 0xf;
 		g_PortalXluFracs[portalnum] = (g_PortalXluFracs[portalnum] & 0xf0ff) | (value << 8);
 	}

--- a/src/game/sky.c
+++ b/src/game/sky.c
@@ -272,6 +272,8 @@ Gfx *skyRender(Gfx *gdl)
 
 			if (g_Vars.currentplayer->visionmode == VISIONMODE_XRAY) {
 				gdl = viSetFillColour(gdl, 0, 0, 0);
+			} else if (g_Vars.stagenum == STAGE_TEST_UFF) {
+				gdl = viSetFillColour(gdl, 255, 255, 255);
 			} else {
 				gdl = viSetFillColour(gdl, env->sky_r, env->sky_g, env->sky_b);
 			}
@@ -289,6 +291,8 @@ Gfx *skyRender(Gfx *gdl)
 
 		if (g_Vars.currentplayer->visionmode == VISIONMODE_XRAY) {
 			gdl = viSetFillColour(gdl, 0, 0, 0);
+		} else if (g_Vars.stagenum == STAGE_TEST_UFF) {
+			gdl = viSetFillColour(gdl, 255, 255, 255);
 		} else {
 			gdl = viSetFillColour(gdl, env->sky_r, env->sky_g, env->sky_b);
 		}
@@ -304,7 +308,11 @@ Gfx *skyRender(Gfx *gdl)
 		return gdl;
 	}
 
-	gdl = viSetFillColour(gdl, env->sky_r, env->sky_g, env->sky_b);
+	if (g_Vars.stagenum == STAGE_TEST_UFF) {
+		gdl = viSetFillColour(gdl, 255, 255, 255);
+	} else {
+		gdl = viSetFillColour(gdl, env->sky_r, env->sky_g, env->sky_b);
+	}
 
 	if (&tl3dpos);
 

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -45,7 +45,11 @@
 #define S32_MAX  2147483647
 #define U32_MAX  4294967295
 #define MINFLOAT ((float)-3.40282346638528860e+38)
+// Some host <math.h> headers already define MAXFLOAT; guard to avoid a
+// -Wmacro-redefined warning emitted by every translation unit.
+#ifndef MAXFLOAT
 #define MAXFLOAT ((float)3.40282346638528860e+38)
+#endif
 
 #define ABS(val)            ((val) > 0 ? (val) : -(val))
 #define ABSF(val)           ((val) > 0.0f ? (val) : -(val))

--- a/src/include/game/gfxreplace.h
+++ b/src/include/game/gfxreplace.h
@@ -6,5 +6,6 @@
 
 void gfxReplaceGbiCommands(Gfx *gdl, Gfx *endgdl, s32 type);
 void gfxReplaceGbiCommandsRecursively(struct roomblock *arg0, s32 type);
+void gfxMakeRoomWhiteRecursively(struct roomblock *block);
 
 #endif

--- a/src/include/game/gfxreplace.h
+++ b/src/include/game/gfxreplace.h
@@ -6,6 +6,6 @@
 
 void gfxReplaceGbiCommands(Gfx *gdl, Gfx *endgdl, s32 type);
 void gfxReplaceGbiCommandsRecursively(struct roomblock *arg0, s32 type);
-void gfxMakeRoomWhiteRecursively(struct roomblock *block);
+void gfxMakeRoomUseShadeRecursively(struct roomblock *block);
 
 #endif


### PR DESCRIPTION
## Summary
- Enable vertex-shaded custom box geometry (gfxreplace/sky/bg).
- Add near-plane triangle clipping in Fast3D PC renderer.
- Force portal-less arena room load, filebg allocation fixes, bbox override.
- Raise PC romdata size estimates; resolve mod paths with stat().

## Test plan
- [ ] `./build/pd.arm64 --test-map --scenario-0 --moddir mods/mod_allinone`
- [ ] Confirm colored box renders without GL heap crash
- [ ] Confirm player stands on floor (no fall-through)

Made with [Cursor](https://cursor.com)