### PR TITLE
mp setups: introduce versions per setup block

### DIFF
--- a/port/include/mpsetups.h
+++ b/port/include/mpsetups.h
@@ -5,7 +5,7 @@
 
 s32 mpsetupLoadCurrentFile(void);
 s32 mpsetupSaveCurrentFile(void);
-void mpsetupLoadSetup(s32 slotindex);
+void mpsetupLoadSetup(s32 setupIdx);
 s32 mpsetupSaveSetup(s32 slotindex, u8 savefile);
 void mpsetupCopyAllFromPak(void);
 

--- a/port/src/mpsetups.c
+++ b/port/src/mpsetups.c
@@ -366,6 +366,16 @@ static s32 mpsetupDeserialize(FILE *f, struct mpsetupfile *setupfile)
 		rx += fread(setupfile->setups[i].bytes, sizeof(setupfile->setups[i].bytes), 1, f);
 	}
 
+	if (setupfile->version == 1) {
+		// block version was not introduced yet, so set them all to 1
+		for (int i = 0; i < MPSETUP_MAXSETUPS; ++i) {
+			setupfile->blockversions[i] = 1;
+		}
+	}
+	else {
+		rx += fread(setupfile->blockversions, MPSETUP_MAXSETUPS, 1, f);
+	}
+
 	return rx;
 }
 
@@ -379,6 +389,10 @@ static s32 mpsetupSerialize(FILE *f, struct mpsetupfile *setupfile)
 
 	for (int i = 0; i < setupfile->numsetups; ++i) {
 		wx += fwrite(setupfile->setups[i].bytes, sizeof(setupfile->setups[i].bytes), 1, f);
+	}
+
+	if (setupfile->version > 1) {
+		wx += fwrite(setupfile->blockversions, MPSETUP_MAXSETUPS, 1, f);
 	}
 
 	return wx;
@@ -493,6 +507,7 @@ static s32 mpsetupImportFile(u8 op, u8 skipOverlap)
 		}
 
 		memcpy(g_MpSetupFile.setups[importIdx].bytes, g_ImportMpSetupFile.setups[i].bytes, MPSETUP_BLOCKSIZE);
+		g_MpSetupFile.blockversions[importIdx] = g_ImportMpSetupFile.blockversions[i];
 	}
 
 	return mpsetupSaveCurrentFile();
@@ -518,6 +533,7 @@ static s32 mpsetupExportFile(void)
 			expMpSetupFile.numsetups = n + 1;
 		}
 	}
+	memcpy(expMpSetupFile.blockversions, g_MpSetupFile.blockversions, MPSETUP_MAXSETUPS);
 
 	s32 err = mpsetupSaveFile(MPSETUP_OP_EXPORT, &expMpSetupFile);
 	if (err) {
@@ -848,18 +864,19 @@ s32 mpsetupSaveSetup(s32 slotindex, u8 savefile)
 	mpsetupfileSaveWad(&setup);
 
 	memcpy(g_MpSetupFile.setups[slotindex].bytes, setup.bytes, MPSETUP_BLOCKSIZE);
+	g_MpSetupFile.blockversions[slotindex] = MPSETUP_VERSION;
 
 	return savefile ? mpsetupSaveCurrentFile() : 0;
 }
 
-void mpsetupLoadSetup(s32 index)
+void mpsetupLoadSetup(s32 setupIdx)
 {
 	struct savebuffer buffer;
 	savebufferClear(&buffer);
-	struct setupblock *block = &g_MpSetupFile.setups[index];
+	struct setupblock *block = &g_MpSetupFile.setups[setupIdx];
 	memcpy(&buffer.bytes, block->bytes, MPSETUP_BLOCKSIZE);
-	mpsetupfileLoadWad(&buffer, g_MpSetupFile.version);
-	g_MpCurrentSetup = index;
+	mpsetupfileLoadWad(&buffer, g_MpSetupFile.blockversions[setupIdx]);
+	g_MpCurrentSetup = setupIdx;
 }
 
 void mpsetupCopyAllFromPak(void)

--- a/src/game/mplayer/mplayer.c
+++ b/src/game/mplayer/mplayer.c
@@ -309,6 +309,7 @@ void mpStartMatch(void)
 		g_Textures[0x0bde].soundsurfacetype = SURFACETYPE_GLASS;
 
 		g_Textures[0x06ff].surfacetype = SURFACETYPE_DEFAULT;
+		g_Textures[0x066c].surfacetype = SURFACETYPE_DEFAULT;
 		g_Textures[0x0716].surfacetype = SURFACETYPE_DEFAULT;
 		g_Textures[0x0716].soundsurfacetype = SURFACETYPE_DEFAULT;
 		g_Textures[0x0a16].surfacetype = SURFACETYPE_DEFAULT;
@@ -321,10 +322,12 @@ void mpStartMatch(void)
 		g_Textures[0x065a].surfacetype = SURFACETYPE_METAL;
 		g_Textures[0x065a].soundsurfacetype = SURFACETYPE_METAL;
 	} else if (g_ModNum == MOD_KAKARIKO) {
+		g_Textures[0x09cd].soundsurfacetype = SURFACETYPE_SHALLOWWATER;
+		g_Textures[0x09ce].soundsurfacetype = SURFACETYPE_SHALLOWWATER;
 		g_Textures[0x0c31].soundsurfacetype = SURFACETYPE_DIRT;
-		g_Textures[0x0c3b].soundsurfacetype = SURFACETYPE_MUD;
-		g_Textures[0x0c3c].soundsurfacetype = SURFACETYPE_MUD;
-		g_Textures[0x0c3d].soundsurfacetype = SURFACETYPE_DIRT;
+		g_Textures[0x0c3b].soundsurfacetype = SURFACETYPE_STONE;
+		g_Textures[0x0c3c].soundsurfacetype = SURFACETYPE_DEFAULT;
+		g_Textures[0x0c3d].soundsurfacetype = SURFACETYPE_NONE;
 		g_Textures[0x0c3e].soundsurfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c42].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c43].soundsurfacetype = SURFACETYPE_STONE;
@@ -332,7 +335,7 @@ void mpStartMatch(void)
 		g_Textures[0x0c48].soundsurfacetype = SURFACETYPE_STONE;
 		g_Textures[0x0c49].soundsurfacetype = SURFACETYPE_MUD;
 		g_Textures[0x0c4a].soundsurfacetype = SURFACETYPE_NONE;
-		g_Textures[0x0c4b].soundsurfacetype = SURFACETYPE_SHALLOWWATER;
+		g_Textures[0x0c4b].soundsurfacetype = SURFACETYPE_MUD;
 		g_Textures[0x0c4c].soundsurfacetype = SURFACETYPE_DEEPWATER;
 		g_Textures[0x0c63].soundsurfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c64].soundsurfacetype = SURFACETYPE_STONE;
@@ -345,6 +348,7 @@ void mpStartMatch(void)
 		g_Textures[0x0c6c].soundsurfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c6e].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c6f].soundsurfacetype = SURFACETYPE_METAL;
+		g_Textures[0x0c72].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c73].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c74].soundsurfacetype = SURFACETYPE_STONE;
 		g_Textures[0x0c75].soundsurfacetype = SURFACETYPE_STONE;
@@ -354,8 +358,10 @@ void mpStartMatch(void)
 		g_Textures[0x0c7a].soundsurfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c7b].soundsurfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c7c].soundsurfacetype = SURFACETYPE_STONE;
+		g_Textures[0x0c7d].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c7e].soundsurfacetype = SURFACETYPE_METAL;
 		g_Textures[0x0c7f].soundsurfacetype = SURFACETYPE_WOOD;
+		g_Textures[0x0c80].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c81].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c82].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c83].soundsurfacetype = SURFACETYPE_STONE;
@@ -366,10 +372,12 @@ void mpStartMatch(void)
 		g_Textures[0x0c8c].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c8d].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c8f].soundsurfacetype = SURFACETYPE_DIRT;
+		g_Textures[0x09cd].surfacetype = SURFACETYPE_SHALLOWWATER;
+		g_Textures[0x09ce].surfacetype = SURFACETYPE_SHALLOWWATER;
 		g_Textures[0x0c31].surfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c3b].surfacetype = SURFACETYPE_MUD;
 		g_Textures[0x0c3c].surfacetype = SURFACETYPE_MUD;
-		g_Textures[0x0c3d].surfacetype = SURFACETYPE_DIRT;
+		g_Textures[0x0c3d].surfacetype = SURFACETYPE_MUD;
 		g_Textures[0x0c3e].surfacetype = SURFACETYPE_NONE;
 		g_Textures[0x0c42].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c43].surfacetype = SURFACETYPE_STONE;
@@ -377,7 +385,7 @@ void mpStartMatch(void)
 		g_Textures[0x0c48].surfacetype = SURFACETYPE_STONE;
 		g_Textures[0x0c49].surfacetype = SURFACETYPE_MUD;
 		g_Textures[0x0c4a].surfacetype = SURFACETYPE_NONE;
-		g_Textures[0x0c4b].surfacetype = SURFACETYPE_SHALLOWWATER;
+		g_Textures[0x0c4b].surfacetype = SURFACETYPE_MUD;
 		g_Textures[0x0c4c].surfacetype = SURFACETYPE_SHALLOWWATER;
 		g_Textures[0x0c63].surfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c64].surfacetype = SURFACETYPE_STONE;
@@ -390,6 +398,7 @@ void mpStartMatch(void)
 		g_Textures[0x0c6c].surfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c6e].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c6f].surfacetype = SURFACETYPE_METAL;
+		g_Textures[0x0c72].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c73].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c74].surfacetype = SURFACETYPE_STONE;
 		g_Textures[0x0c75].surfacetype = SURFACETYPE_STONE;
@@ -398,9 +407,11 @@ void mpStartMatch(void)
 		g_Textures[0x0c79].surfacetype = SURFACETYPE_STONE;
 		g_Textures[0x0c7a].surfacetype = SURFACETYPE_DIRT;
 		g_Textures[0x0c7b].surfacetype = SURFACETYPE_DIRT;
-		g_Textures[0x0c7c].surfacetype = SURFACETYPE_STONE;
+		g_Textures[0x0c7c].surfacetype = SURFACETYPE_WOOD;
+		g_Textures[0x0c7d].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c7e].surfacetype = SURFACETYPE_METAL;
 		g_Textures[0x0c7f].surfacetype = SURFACETYPE_WOOD;
+		g_Textures[0x0c80].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c81].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c82].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0c83].surfacetype = SURFACETYPE_STONE;
@@ -440,6 +451,7 @@ void mpStartMatch(void)
 		g_Textures[0x0065].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0067].soundsurfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0068].soundsurfacetype = SURFACETYPE_WOOD;
+		g_Textures[0x00fa].soundsurfacetype = SURFACETYPE_DEFAULT;
 		g_Textures[0x0048].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0049].surfacetype = SURFACETYPE_MUD;
 		g_Textures[0x004A].surfacetype = SURFACETYPE_MUD;
@@ -466,6 +478,7 @@ void mpStartMatch(void)
 		g_Textures[0x0065].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0067].surfacetype = SURFACETYPE_WOOD;
 		g_Textures[0x0068].surfacetype = SURFACETYPE_WOOD;
+		g_Textures[0x00fa].surfacetype = SURFACETYPE_DEFAULT;
 	} else if (g_ModNum == MOD_GOLDFINGER_64) {
 		g_Textures[0x0281].surfacetype = SURFACETYPE_DEFAULT;
 		g_Textures[0x0281].soundsurfacetype = SURFACETYPE_DEFAULT;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -6171,6 +6171,7 @@ struct mpsetupfile {
 	u8 defaultsetup;
 	u8 numsetups;
 	struct setupblock setups[MPSETUP_MAXSETUPS];
+	u8 blockversions[MPSETUP_MAXSETUPS];
 };
 
 #endif


### PR DESCRIPTION
Now every setup block has its own version, so we can change the internal structure of setups while maintaining compatibility with setups that were not upgraded yet.